### PR TITLE
Added strip.placement = "outside"

### DIFF
--- a/R/theme_gecko.R
+++ b/R/theme_gecko.R
@@ -132,7 +132,8 @@ theme_gecko <- function(font_family = "Noto Sans", # Default font family
           face = "bold", # Bold typeface
           size = axis_title_size, # Font size
           vjust = 1
-        )
+        ),
+        strip.placement = "outside"
       )
   )
 }


### PR DESCRIPTION
Using a secondary y-axis, facet_grid with the strip.background = ggplot2::element_blank() in the theme results in the label being between the border of the plot and the axis ticks, which looks strange. strip.placement = "outside" moves the axis to the plot and the label further outside resulting in a better appearance.